### PR TITLE
Add admin page for YCH editing

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,25 @@
 # wildstrokes.art
+
+## Updating YCHs
+
+All YCH slots are stored in `ych/ychs.json`. Each entry looks like:
+
+```json
+{
+  "image": "filename.png",
+  "title": "YCH Title",
+  "usd": 45,
+  "options": ["Option text", "More options"]
+}
+```
+
+Add new objects or edit the existing ones to change what appears on the YCH page. Images should live in the `ych/` folder and the site will automatically render them when `ych/index.html` is loaded.
+
+### Editing via Admin Page
+
+To update YCHs without using GitHub directly, open `ych/admin.html` in your
+browser. The page is protected by a simple password (edit `js/ych-admin.js` to
+change it). After entering the password you can modify the JSON in the textbox
+and click **Save**. You'll be prompted for a GitHub token so the page can commit
+the changes to this repository using the GitHub API. Update the repository name
+inside `js/ych-admin.js` if your fork uses a different path.

--- a/js/render-ych.js
+++ b/js/render-ych.js
@@ -1,0 +1,44 @@
+
+document.addEventListener('DOMContentLoaded', async () => {
+  try {
+    const res = await fetch('ychs.json');
+    const ychs = await res.json();
+    const grid = document.querySelector('.ych-grid');
+    if (!grid) return;
+    ychs.forEach(item => {
+      const fig = document.createElement('figure');
+      fig.className = 'ych-card';
+
+      const img = document.createElement('img');
+      img.src = item.image;
+      img.alt = `${item.title} YCH`;
+      fig.appendChild(img);
+
+      const cap = document.createElement('figcaption');
+
+      const h2 = document.createElement('h2');
+      h2.textContent = `${item.title} - $${item.usd}`;
+      cap.appendChild(h2);
+
+      const price = document.createElement('span');
+      price.className = 'price';
+      price.dataset.usd = Number(item.usd).toFixed(2);
+      cap.appendChild(price);
+
+      const ul = document.createElement('ul');
+      ul.className = 'ych-options';
+      (item.options || []).forEach(opt => {
+        const li = document.createElement('li');
+        li.textContent = opt;
+        ul.appendChild(li);
+      });
+      cap.appendChild(ul);
+
+      fig.appendChild(cap);
+      grid.appendChild(fig);
+    });
+  } catch (err) {
+    console.error('Failed to render YCHs:', err);
+  }
+});
+

--- a/js/ych-admin.js
+++ b/js/ych-admin.js
@@ -1,0 +1,51 @@
+(function() {
+  document.addEventListener('DOMContentLoaded', async function() {
+    const pw = prompt('Password:');
+    if (pw !== 'change-me') {
+      alert('Incorrect password');
+      window.location.href = '../index.html';
+      return;
+    }
+
+    const textarea = document.getElementById('ych-json');
+    try {
+      const res = await fetch('ychs.json?cache=' + Date.now());
+      textarea.value = await res.text();
+    } catch (err) {
+      console.error(err);
+      alert('Failed to load current YCHs');
+    }
+
+    document.getElementById('saveButton').addEventListener('click', async () => {
+      const token = prompt('GitHub token:');
+      if (!token) return;
+
+      const repo = 'USERNAME/wildstrokes.art'; // TODO: update to your repo
+      const path = 'ych/ychs.json';
+      const apiUrl = `https://api.github.com/repos/${repo}/contents/${path}`;
+      try {
+        const infoRes = await fetch(apiUrl, { headers: { Authorization: `token ${token}` } });
+        const info = await infoRes.json();
+        const body = {
+          message: 'Update YCHs via admin page',
+          content: btoa(unescape(encodeURIComponent(textarea.value)) ),
+          sha: info.sha
+        };
+        const putRes = await fetch(apiUrl, {
+          method: 'PUT',
+          headers: { 'Content-Type': 'application/json', Authorization: `token ${token}` },
+          body: JSON.stringify(body)
+        });
+        if (putRes.ok) {
+          alert('Updated!');
+        } else {
+          const t = await putRes.text();
+          alert('Failed: ' + t);
+        }
+      } catch (e) {
+        console.error(e);
+        alert('Error updating file');
+      }
+    });
+  });
+})();

--- a/ych/admin.html
+++ b/ych/admin.html
@@ -1,0 +1,17 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <title>Edit YCHs</title>
+  <meta name="viewport" content="width=device-width, initial-scale=1" />
+  <link rel="stylesheet" href="../style.css" />
+</head>
+<body>
+  <h1>Edit YCHs</h1>
+  <textarea id="ych-json" rows="20" style="width:100%;"></textarea>
+  <br />
+  <button id="saveButton">Save</button>
+  <p style="margin-top:1rem;font-size:0.9rem;">Changes are committed directly to GitHub.</p>
+  <script src="../js/ych-admin.js"></script>
+</body>
+</html>

--- a/ych/index.html
+++ b/ych/index.html
@@ -56,49 +56,14 @@
 
     <main class="ych-grid">
 
-      <figure class="ych-card">
-        <img src="Untitled_Artwork-1.png" alt="Steep Relief YCH">
-        <figcaption>
-          <h2>Steep Relief - $45</h2>
-          <span class="price" data-usd="45.00"></span>
-          <script src="../currency.js"></script>
-          <ul class="ych-options">
-            <li>+$10 — Change outfit</li>
-            <li>+$10 — Change pose</li>
-            <li>+$10 — Significant body type change</li>
-          </ul>
-        </figcaption>
-      </figure>
-
-      <figure class="ych-card">
-  <img src="78f5b5c5-20f8-4fae-acec-0dd7335164bf.png" alt="Rest Stop YCH">
-  <figcaption>
-    <h2>Rest Stop - $45</h2>
-    <span class="price" data-usd="45.00"></span>
-    <ul class="ych-options">
-      <li>Any gender</li>
-      <li>Any color clothes</li>
-      <li>Custom license plate</li>
-    </ul>
-  </figcaption>
-</figure>
-
-      <figure class="ych-card">
-        <img src="IMG_1147.jpeg" alt="Moonlit YCH">
-        <figcaption>
-          <h2>Moonlit YCH - $45</h2>
-          <span class="price" data-usd="45.00"></span>
-          <ul class="ych-options">
-            <li>Flaccid male anatomy only</li>
-          </ul>
-        </figcaption>
-      </figure>
 
     </main>
 
   </div>
 
   <button id="clearButton" onclick="clearVerification()">Clear Age Verification</button>
+  <script src="../js/render-ych.js"></script>
+  <script src="../currency.js"></script>
 
 </body>
 </html>

--- a/ych/ychs.json
+++ b/ych/ychs.json
@@ -1,0 +1,20 @@
+[
+  {
+    "image": "Untitled_Artwork-1.png",
+    "title": "Steep Relief",
+    "usd": 45,
+    "options": ["+$10 — Change outfit", "+$10 — Change pose", "+$10 — Significant body type change"]
+  },
+  {
+    "image": "78f5b5c5-20f8-4fae-acec-0dd7335164bf.png",
+    "title": "Rest Stop",
+    "usd": 45,
+    "options": ["Any gender", "Any color clothes", "Custom license plate"]
+  },
+  {
+    "image": "IMG_1147.jpeg",
+    "title": "Moonlit YCH",
+    "usd": 45,
+    "options": ["Flaccid male anatomy only"]
+  }
+]


### PR DESCRIPTION
## Summary
- create `ych/admin.html` with textarea interface
- add `js/ych-admin.js` to update `ychs.json` via GitHub API
- document the admin workflow

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_687d850cbf44832f9fbf5cf0c919d0cf