### PR TITLE
Add YCH admin upload feature

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,4 +13,14 @@ All YCH slots are stored in `ych/ychs.json`. Each entry looks like:
 }
 ```
 
-Add new objects or edit the existing ones to change what appears on the YCH page. Images should live in the `ych/` folder and the site will automatically render them when `ych/index.html` is loaded.
+Add new objects or edit the existing ones to change what appears on the YCH page.
+Images should live in the `ych/` folder and the site will automatically render
+them when `ych/index.html` is loaded.
+
+### Admin page
+
+`ych/admin.html` provides a simple local admin interface. Log in with the
+password `artadmin` to add, edit or remove YCH entries. Images can be uploaded
+from your computer; they are stored as data URLs in `localStorage` so no GitHub
+upload is needed. All changes only affect your browser and override
+`ychs.json` when rendering the normal YCH page.

--- a/js/admin-ych.js
+++ b/js/admin-ych.js
@@ -1,0 +1,123 @@
+const PASSWORD = 'artadmin';
+
+const loginDiv = document.getElementById('login');
+const adminDiv = document.getElementById('admin');
+const passInput = document.getElementById('admin-pass');
+const loginBtn = document.getElementById('login-btn');
+const logoutBtn = document.getElementById('logout-btn');
+const addBtn = document.getElementById('add-btn');
+const saveBtn = document.getElementById('save-btn');
+const ychList = document.getElementById('ych-list');
+
+let ychs = [];
+
+function renderList() {
+  ychList.innerHTML = '';
+  ychs.forEach((item, idx) => {
+    const div = document.createElement('div');
+    div.className = 'ych-card';
+
+    const val = item.image && item.image.startsWith('data:') ? '' : (item.image || '');
+
+    div.innerHTML = `
+      <img data-idx="${idx}" src="${item.image}" class="preview" style="max-width:150px"><br>
+      <label>Upload Image: <input type="file" data-idx="${idx}" class="img-upload"></label><br>
+      <label>Image URL: <input data-idx="${idx}" data-field="image" value="${val}" placeholder="filename or url"></label><br>
+      <label>Title: <input data-idx="${idx}" data-field="title" value="${item.title}"></label><br>
+      <label>USD: <input type="number" data-idx="${idx}" data-field="usd" value="${item.usd}"></label><br>
+      <label>Options (comma separated):<br><textarea data-idx="${idx}" data-field="options">${(item.options||[]).join(', ')}</textarea></label><br>
+      <button data-idx="${idx}" class="delete-btn">Delete</button>
+    `;
+    ychList.appendChild(div);
+  });
+}
+
+function loadData() {
+  const stored = localStorage.getItem('ychAdmin');
+  if (stored) {
+    try { ychs = JSON.parse(stored); } catch(e) { ychs = []; }
+    renderList();
+    return;
+  }
+  fetch('ychs.json')
+    .then(res => res.json())
+    .then(data => { ychs = data; renderList(); })
+    .catch(err => console.error('Failed to load ychs', err));
+}
+
+function saveData() {
+  localStorage.setItem('ychAdmin', JSON.stringify(ychs));
+  alert('Saved to localStorage. Updates will appear on the YCH page.');
+}
+
+loginBtn.addEventListener('click', () => {
+  if (passInput.value === PASSWORD) {
+    localStorage.setItem('ychAdminAuthed', 'true');
+    loginDiv.style.display = 'none';
+    adminDiv.style.display = 'block';
+    loadData();
+  } else {
+    alert('Incorrect password');
+  }
+});
+
+logoutBtn.addEventListener('click', () => {
+  localStorage.removeItem('ychAdminAuthed');
+  location.reload();
+});
+
+addBtn.addEventListener('click', () => {
+  ychs.push({image:'', title:'', usd:0, options:[]});
+  renderList();
+});
+
+saveBtn.addEventListener('click', () => {
+  const inputs = document.querySelectorAll('[data-field]');
+  inputs.forEach(input => {
+    const idx = input.dataset.idx;
+    const field = input.dataset.field;
+    if (!field) return;
+    if (field === 'options') {
+      ychs[idx][field] = input.value.split(',').map(s => s.trim()).filter(s=>s);
+    } else if (field === 'usd') {
+      ychs[idx][field] = Number(input.value);
+    } else if (field === 'image') {
+      if (input.value.trim()) {
+        ychs[idx][field] = input.value.trim();
+      }
+    } else {
+      ychs[idx][field] = input.value;
+    }
+  });
+  saveData();
+  renderList();
+});
+
+document.addEventListener('click', evt => {
+  if (evt.target.classList.contains('delete-btn')) {
+    const idx = evt.target.dataset.idx;
+    ychs.splice(idx,1);
+    renderList();
+  }
+});
+
+document.addEventListener('change', evt => {
+  if (evt.target.classList.contains('img-upload')) {
+    const idx = evt.target.dataset.idx;
+    const file = evt.target.files[0];
+    if (!file) return;
+    const reader = new FileReader();
+    reader.onload = e => {
+      ychs[idx].image = e.target.result;
+      const img = document.querySelector(`img[data-idx="${idx}"]`);
+      if (img) img.src = e.target.result;
+    };
+    reader.readAsDataURL(file);
+  }
+});
+
+if (localStorage.getItem('ychAdminAuthed') === 'true') {
+  loginDiv.style.display = 'none';
+  adminDiv.style.display = 'block';
+  loadData();
+}

--- a/js/render-ych.js
+++ b/js/render-ych.js
@@ -1,8 +1,15 @@
 
 document.addEventListener('DOMContentLoaded', async () => {
   try {
-    const res = await fetch('ychs.json');
-    const ychs = await res.json();
+    let ychs;
+    const stored = localStorage.getItem('ychAdmin');
+    if (stored) {
+      try { ychs = JSON.parse(stored); } catch(e) { ychs = null; }
+    }
+    if (!ychs) {
+      const res = await fetch('ychs.json');
+      ychs = await res.json();
+    }
     const grid = document.querySelector('.ych-grid');
     if (!grid) return;
     ychs.forEach(item => {
@@ -41,4 +48,3 @@ document.addEventListener('DOMContentLoaded', async () => {
     console.error('Failed to render YCHs:', err);
   }
 });
-

--- a/ych/admin.html
+++ b/ych/admin.html
@@ -1,0 +1,32 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <title>YCH Admin | WildStrokes</title>
+  <meta name="viewport" content="width=device-width, initial-scale=1" />
+  <link rel="stylesheet" href="../style.css" />
+  <script src="../js/admin-ych.js" defer></script>
+</head>
+<body>
+  <div id="login">
+    <h2>Admin Login</h2>
+    <input type="password" id="admin-pass" placeholder="Password" />
+    <button id="login-btn">Login</button>
+  </div>
+
+  <div id="admin" style="display:none;">
+    <header class="site-header">
+      <h1>YCH Admin</h1>
+      <button id="logout-btn">Logout</button>
+    </header>
+
+    <main>
+      <p>Use "Upload Image" to attach a picture from your computer or type a URL
+        in the "Image URL" field. Changes are saved locally.</p>
+      <button id="add-btn">Add New YCH</button>
+      <div id="ych-list"></div>
+      <button id="save-btn">Save Changes</button>
+    </main>
+  </div>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- add ability to upload images in the YCH admin page
- store uploaded images as data URLs in `localStorage`
- document file upload support in the README

## Testing
- `git status --short`


------
https://chatgpt.com/codex/tasks/task_e_687d91ad3ee4832face9b762a08dcb6d