### PR TITLE
Add site-wide nav

### DIFF
--- a/index.html
+++ b/index.html
@@ -10,6 +10,12 @@
     </script>
 </head>
 <body>
+    <nav class="site-nav">
+        <a href="/">Home</a>
+        <a href="/portfolio">Portfolio</a>
+        <a href="/ych">YCH</a>
+        <a href="/membership">Membership</a>
+    </nav>
     <div id="content">
         <h1>Welcome to WildStrokes</h1>
 

--- a/membership/index.html
+++ b/membership/index.html
@@ -7,6 +7,12 @@
   <link rel="stylesheet" href="../style.css" />
 </head>
 <body>
+  <nav class="site-nav">
+    <a href="/">Home</a>
+    <a href="/portfolio">Portfolio</a>
+    <a href="/ych">YCH</a>
+    <a href="/membership">Membership</a>
+  </nav>
 
   <div id="content">
     <header class="site-header">

--- a/portfolio/index.html
+++ b/portfolio/index.html
@@ -13,6 +13,12 @@
     </script>
 </head>
 <body>
+    <nav class="site-nav">
+        <a href="/">Home</a>
+        <a href="/portfolio">Portfolio</a>
+        <a href="/ych">YCH</a>
+        <a href="/membership">Membership</a>
+    </nav>
     <a class="button" href="https://wildstrokes.art">← Back to Main Page</a>
     <div id="content">
         <header class="site-header">

--- a/style.css
+++ b/style.css
@@ -23,6 +23,29 @@ body {
     color: #555;
 }
 
+
+/* Site-wide navigation */
+.site-nav {
+    display: flex;
+    justify-content: center;
+    gap: 15px;
+    margin-bottom: 20px;
+}
+
+.site-nav a {
+    display: inline-block;
+    padding: 10px 20px;
+    background-color: #cce5ff;
+    color: #333;
+    text-decoration: none;
+    border-radius: 10px;
+    transition: background-color 0.3s;
+}
+
+.site-nav a:hover {
+    background-color: #b3d9ff;
+}
+
 /* YCH grid – give the whole row breathing room */
 .ych-grid {
   display: flex;

--- a/ych/index.html
+++ b/ych/index.html
@@ -11,6 +11,12 @@
   </script>
 </head>
 <body>
+  <nav class="site-nav">
+    <a href="/">Home</a>
+    <a href="/portfolio">Portfolio</a>
+    <a href="/ych">YCH</a>
+    <a href="/membership">Membership</a>
+  </nav>
 
   <div id="content">
 


### PR DESCRIPTION
## Summary
- create CSS rules for `.site-nav`
- inject navigation bar on home, portfolio, membership and YCH pages
- keep the YCH admin page unchanged

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_687ea8282c14832faa91dafcd0fea88f