### PR TITLE
Add Ko-fi and Bluesky buttons to menu

### DIFF
--- a/index.html
+++ b/index.html
@@ -14,6 +14,8 @@
         <a href="/">Home</a>
         <a href="/portfolio">Portfolio</a>
         <a href="/ych">YCH</a>
+        <a href="https://ko-fi.com/wildstrokes" target="_blank">Kofi</a>
+        <a href="https://bsky.app/profile/wildstrokes.art" target="_blank">Bluesky</a>
     </nav>
     <div id="content">
         <h1>Welcome to WildStrokes</h1>

--- a/membership/index.html
+++ b/membership/index.html
@@ -11,6 +11,8 @@
     <a href="/">Home</a>
     <a href="/portfolio">Portfolio</a>
     <a href="/ych">YCH</a>
+    <a href="https://ko-fi.com/wildstrokes" target="_blank">Kofi</a>
+    <a href="https://bsky.app/profile/wildstrokes.art" target="_blank">Bluesky</a>
   </nav>
 
   <div id="content">

--- a/portfolio/index.html
+++ b/portfolio/index.html
@@ -17,6 +17,8 @@
         <a href="/">Home</a>
         <a href="/portfolio">Portfolio</a>
         <a href="/ych">YCH</a>
+        <a href="https://ko-fi.com/wildstrokes" target="_blank">Kofi</a>
+        <a href="https://bsky.app/profile/wildstrokes.art" target="_blank">Bluesky</a>
     </nav>
     <a class="button" href="https://wildstrokes.art">← Back to Main Page</a>
     <div id="content">

--- a/ych/index.html
+++ b/ych/index.html
@@ -15,6 +15,8 @@
     <a href="/">Home</a>
     <a href="/portfolio">Portfolio</a>
     <a href="/ych">YCH</a>
+    <a href="https://ko-fi.com/wildstrokes" target="_blank">Kofi</a>
+    <a href="https://bsky.app/profile/wildstrokes.art" target="_blank">Bluesky</a>
   </nav>
 
   <div id="content">


### PR DESCRIPTION
## Summary
- add Ko-fi and Bluesky buttons across the site's nav bar

## Testing
- `apt-get install -y tidy` *(fails: package not found)*

------
https://chatgpt.com/codex/tasks/task_e_687eb07a7e4c832fb2595774afe5bc25