### PR TITLE
Fix menu width on small screens

### DIFF
--- a/style.css
+++ b/style.css
@@ -28,6 +28,7 @@ body {
 .site-nav {
     display: flex;
     justify-content: center;
+    flex-wrap: wrap;
     gap: 15px;
     margin-bottom: 20px;
 }


### PR DESCRIPTION
## Summary
- allow the site navigation menu to wrap when space is limited

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_687ed1467320832faed136430c66341e