### PR TITLE
Add reorder controls to YCH editor

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,6 +20,7 @@ them when `ych/index.html` is loaded.
 For quick edits, open `ych/editor.html` in your browser. It now shows each YCH
 in a small form so you can easily change the image path, title, price and
 options. Use the **Add YCH** button to insert new entries or the **Remove**
-button to delete them. When you're done, click **Download JSON** and commit the
+button to delete them. Up and Down buttons let you reorder the YCHs.
+When you're done, click **Download JSON** and commit the
 file back to the repo.
 

--- a/js/edit-ych.js
+++ b/js/edit-ych.js
@@ -49,7 +49,29 @@ function addItem(item = { image: '', title: '', usd: '', options: [] }) {
   remove.className = 'button';
   remove.addEventListener('click', () => div.remove());
 
-  div.append(img.wrapper, title.wrapper, price.wrapper, opts.wrapper, remove);
+  const up = document.createElement('button');
+  up.textContent = 'Up';
+  up.className = 'button';
+  up.addEventListener('click', () => {
+    if (div.previousElementSibling) {
+      container.insertBefore(div, div.previousElementSibling);
+    }
+  });
+
+  const down = document.createElement('button');
+  down.textContent = 'Down';
+  down.className = 'button';
+  down.addEventListener('click', () => {
+    if (div.nextElementSibling) {
+      container.insertBefore(div.nextElementSibling, div);
+    }
+  });
+
+  const controls = document.createElement('div');
+  controls.className = 'ych-edit-controls';
+  controls.append(up, down, remove);
+
+  div.append(img.wrapper, title.wrapper, price.wrapper, opts.wrapper, controls);
   container.appendChild(div);
 }
 

--- a/style.css
+++ b/style.css
@@ -180,3 +180,11 @@ button.button:hover {
     margin-top: 4px;
     margin-bottom: 12px;
 }
+
+.ych-edit-controls {
+    margin-top: 10px;
+}
+
+.ych-edit-controls .button {
+    margin-right: 10px;
+}


### PR DESCRIPTION
## Summary
- allow moving YCH items up or down in the editor
- style editor control buttons
- mention reordering in README

## Testing
- `npm test` *(fails: could not find package.json)*

------
https://chatgpt.com/codex/tasks/task_e_687f061eab30832fb813aff629b5e472