### PR TITLE
Improve site metadata and age gate

### DIFF
--- a/index.html
+++ b/index.html
@@ -4,21 +4,26 @@
    <meta charset="UTF-8">
    <title>WildStrokes (18+)</title>
    <meta name="viewport" content="width=device-width, initial-scale=1" />
-    <link rel="stylesheet" href="/style.css">
-    <style>#content { display: none; }</style>
-    <script src="/js/age-gate.js" defer></script>
-    <script defer>
+   <meta name="description" content="WildStrokes features adult furry artwork and commission YCH slots." />
+   <meta property="og:title" content="WildStrokes" />
+   <meta property="og:description" content="Adult furry artwork and YCH commissions." />
+   <meta property="og:type" content="website" />
+   <meta property="og:url" content="https://wildstrokes.art/" />
+   <meta property="og:image" content="https://wildstrokes.art/assets/c302bf84-6868-403c-8c0a-5e410fad1dae.png" />
+   <meta name="twitter:card" content="summary_large_image" />
+   <meta name="twitter:title" content="WildStrokes" />
+   <meta name="twitter:description" content="Adult furry artwork and YCH commissions." />
+   <meta name="twitter:image" content="https://wildstrokes.art/assets/c302bf84-6868-403c-8c0a-5e410fad1dae.png" />
+   <link rel="stylesheet" href="/style.css">
+   <style>#content { display: none; }</style>
+   <script src="/js/age-gate.js" defer></script>
+   <script src="/js/nav.js" defer></script>
+   <script defer>
       document.addEventListener('DOMContentLoaded', () => initAgeGate());
-    </script>
+   </script>
 </head>
 <body>
-    <nav class="site-nav">
-        <a href="/">Home</a>
-        <a href="/portfolio">Portfolio</a>
-        <a href="/ych">YCH</a>
-        <a href="https://ko-fi.com/wildstrokes" target="_blank">Kofi</a>
-        <a href="https://bsky.app/profile/wildstrokes.art" target="_blank">Bluesky</a>
-    </nav>
+    <div id="nav-placeholder"></div>
     <div id="content">
         <h1>Welcome to WildStrokes</h1>
 
@@ -30,7 +35,7 @@
 
         <a class="button" href="https://bsky.app/profile/wildstrokes.art" target="_blank">@wildstrokes.art</a>
 
-        <img src="/assets/c302bf84-6868-403c-8c0a-5e410fad1dae.png" alt="WildStrokes Comic" class="feature-image">
+        <img src="/assets/c302bf84-6868-403c-8c0a-5e410fad1dae.png" alt="WildStrokes Comic" class="feature-image" loading="lazy">
 
         <button id="clearButton" onclick="clearAgeVerification()">Clear Age Verification</button>
 

--- a/js/age-gate.js
+++ b/js/age-gate.js
@@ -6,15 +6,28 @@ function initAgeGate(opts = {}) {
   const show = () => { if (content) content.style.display = 'block'; };
   if (localStorage.getItem('ageVerified') === 'true') {
     show();
-  } else {
-    const confirmed = confirm(msg);
-    if (confirmed) {
-      localStorage.setItem('ageVerified', 'true');
-      show();
-    } else {
-      window.location.href = redirect;
-    }
+    return;
   }
+
+  const overlay = document.createElement('div');
+  overlay.className = 'age-gate-overlay';
+  overlay.innerHTML = `
+    <div class="age-gate-dialog">
+      <p>${msg}</p>
+      <button id="age-yes">Yes</button>
+      <button id="age-no">No</button>
+    </div>`;
+  document.body.appendChild(overlay);
+
+  document.getElementById('age-yes').addEventListener('click', () => {
+    localStorage.setItem('ageVerified', 'true');
+    overlay.remove();
+    show();
+  });
+
+  document.getElementById('age-no').addEventListener('click', () => {
+    window.location.href = redirect;
+  });
 }
 
 function clearAgeVerification() {

--- a/js/nav.js
+++ b/js/nav.js
@@ -1,0 +1,9 @@
+document.addEventListener('DOMContentLoaded', () => {
+  const placeholder = document.getElementById('nav-placeholder');
+  if (!placeholder) return;
+  fetch('/nav.html')
+    .then(res => res.text())
+    .then(html => {
+      placeholder.innerHTML = html;
+    });
+});

--- a/membership/index.html
+++ b/membership/index.html
@@ -4,16 +4,26 @@
   <meta charset="UTF-8" />
   <title>Membership | WildStrokes</title>
   <meta name="viewport" content="width=device-width, initial-scale=1" />
+  <meta name="description" content="Join the WildStrokes membership for exclusive previews and perks." />
+  <meta property="og:title" content="Membership | WildStrokes" />
+  <meta property="og:description" content="Join the WildStrokes membership for exclusive previews and perks." />
+  <meta property="og:type" content="website" />
+  <meta property="og:url" content="https://wildstrokes.art/membership/" />
+  <meta property="og:image" content="https://wildstrokes.art/assets/c302bf84-6868-403c-8c0a-5e410fad1dae.png" />
+  <meta name="twitter:card" content="summary_large_image" />
+  <meta name="twitter:title" content="Membership | WildStrokes" />
+  <meta name="twitter:description" content="Join the WildStrokes membership for exclusive previews and perks." />
+  <meta name="twitter:image" content="https://wildstrokes.art/assets/c302bf84-6868-403c-8c0a-5e410fad1dae.png" />
   <link rel="stylesheet" href="../style.css" />
+  <style>#content { display: none; }</style>
+  <script src="../js/age-gate.js" defer></script>
+  <script src="/js/nav.js" defer></script>
+  <script defer>
+    document.addEventListener('DOMContentLoaded', () => initAgeGate());
+  </script>
 </head>
 <body>
-  <nav class="site-nav">
-    <a href="/">Home</a>
-    <a href="/portfolio">Portfolio</a>
-    <a href="/ych">YCH</a>
-    <a href="https://ko-fi.com/wildstrokes" target="_blank">Kofi</a>
-    <a href="https://bsky.app/profile/wildstrokes.art" target="_blank">Bluesky</a>
-  </nav>
+  <div id="nav-placeholder"></div>
 
   <div id="content">
     <header class="site-header">
@@ -33,6 +43,8 @@
       <p>Become a member to support my work and get insider access.</p>
       <div id="paypal-button-container-P-0F008842126119604NA2MVAA"></div>
     </section>
+    <button id="clearButton" onclick="clearAgeVerification()">Clear Age Verification</button>
+    <footer class="site-footer">© 2024 WildStrokes. All rights reserved.</footer>
   </div>
 
   <script src="https://www.paypal.com/sdk/js?client-id=AQRhOvnkPsVu6kZ5_EMMY0RPYrzQ5ivhELN917zpJsNDwELxf7PS21mbZ30igS-WL9yfpPHP6ueDyJPp&vault=true&intent=subscription" data-sdk-integration-source="button-factory"></script>

--- a/nav.html
+++ b/nav.html
@@ -1,0 +1,7 @@
+<nav class="site-nav">
+  <a href="/">Home</a>
+  <a href="/portfolio">Portfolio</a>
+  <a href="/ych">YCH</a>
+  <a href="https://ko-fi.com/wildstrokes" target="_blank">Kofi</a>
+  <a href="https://bsky.app/profile/wildstrokes.art" target="_blank">Bluesky</a>
+</nav>

--- a/portfolio/index.html
+++ b/portfolio/index.html
@@ -4,23 +4,28 @@
     <meta charset="UTF-8">
     <title>WildStrokes Portfolio (18+)</title>
     <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <meta name="description" content="View the adult art portfolio of WildStrokes." />
+    <meta property="og:title" content="WildStrokes Portfolio" />
+    <meta property="og:description" content="View the adult art portfolio of WildStrokes." />
+    <meta property="og:type" content="website" />
+    <meta property="og:url" content="https://wildstrokes.art/portfolio/" />
+    <meta property="og:image" content="https://wildstrokes.art/assets/c302bf84-6868-403c-8c0a-5e410fad1dae.png" />
+    <meta name="twitter:card" content="summary_large_image" />
+    <meta name="twitter:title" content="WildStrokes Portfolio" />
+    <meta name="twitter:description" content="View the adult art portfolio of WildStrokes." />
+    <meta name="twitter:image" content="https://wildstrokes.art/assets/c302bf84-6868-403c-8c0a-5e410fad1dae.png" />
     <link rel="stylesheet" href="../style.css">
     <style>
         #content { display: none; }
     </style>
     <script src="../js/age-gate.js" defer></script>
+    <script src="/js/nav.js" defer></script>
     <script defer>
         document.addEventListener('DOMContentLoaded', () => initAgeGate({ redirect: 'https://wildstrokes.art' }));
     </script>
 </head>
 <body>
-    <nav class="site-nav">
-        <a href="/">Home</a>
-        <a href="/portfolio">Portfolio</a>
-        <a href="/ych">YCH</a>
-        <a href="https://ko-fi.com/wildstrokes" target="_blank">Kofi</a>
-        <a href="https://bsky.app/profile/wildstrokes.art" target="_blank">Bluesky</a>
-    </nav>
+    <div id="nav-placeholder"></div>
     <a class="button" href="https://wildstrokes.art">← Back to Main Page</a>
     <div id="content">
         <header class="site-header">
@@ -28,15 +33,15 @@
         </header>
 
         <div class="portfolio-gallery">
-            <img src="../assets/IMG_1494.jpeg" alt="Artwork 1">
-            <img src="../assets/IMG_1495.jpeg" alt="Artwork 2">
-            <img src="../assets/IMG_1496.jpeg" alt="Artwork 3">
-            <img src="../assets/IMG_1497.jpeg" alt="Artwork 4">
-            <img src="../assets/IMG_1498.jpeg" alt="Artwork 5">
-            <img src="../assets/IMG_1499.jpeg" alt="Artwork 6">
-            <img src="../assets/IMG_1500.jpeg" alt="Artwork 7">
-            <img src="../assets/IMG_1501.jpeg" alt="Artwork 8">
-            <img src="../assets/IMG_1502.jpeg" alt="Artwork 9">
+            <img src="../assets/IMG_1494.jpeg" alt="Artwork 1" loading="lazy">
+            <img src="../assets/IMG_1495.jpeg" alt="Artwork 2" loading="lazy">
+            <img src="../assets/IMG_1496.jpeg" alt="Artwork 3" loading="lazy">
+            <img src="../assets/IMG_1497.jpeg" alt="Artwork 4" loading="lazy">
+            <img src="../assets/IMG_1498.jpeg" alt="Artwork 5" loading="lazy">
+            <img src="../assets/IMG_1499.jpeg" alt="Artwork 6" loading="lazy">
+            <img src="../assets/IMG_1500.jpeg" alt="Artwork 7" loading="lazy">
+            <img src="../assets/IMG_1501.jpeg" alt="Artwork 8" loading="lazy">
+            <img src="../assets/IMG_1502.jpeg" alt="Artwork 9" loading="lazy">
         </div>
 
         <button class="button" id="clearButton" onclick="clearAgeVerification()">Clear Age Verification</button>

--- a/style.css
+++ b/style.css
@@ -215,3 +215,26 @@ button.button:hover {
     border: 2px solid #555;
     border-radius: 10px;
 }
+
+/* Age gate overlay */
+.age-gate-overlay {
+    position: fixed;
+    inset: 0;
+    background: rgba(0, 0, 0, 0.8);
+    display: flex;
+    justify-content: center;
+    align-items: center;
+    z-index: 10000;
+}
+
+.age-gate-dialog {
+    background: #fff;
+    padding: 20px;
+    border-radius: 8px;
+    text-align: center;
+}
+
+.age-gate-dialog button {
+    margin: 0 10px;
+    padding: 8px 16px;
+}

--- a/ych/index.html
+++ b/ych/index.html
@@ -4,21 +4,26 @@
   <meta charset="UTF-8" />
   <title>YCH Slots | WildStrokes</title>
   <meta name="viewport" content="width=device-width, initial-scale=1" />
+  <meta name="description" content="Browse YCH slot offerings from WildStrokes." />
+  <meta property="og:title" content="YCH Slots | WildStrokes" />
+  <meta property="og:description" content="Browse YCH slot offerings from WildStrokes." />
+  <meta property="og:type" content="website" />
+  <meta property="og:url" content="https://wildstrokes.art/ych/" />
+  <meta property="og:image" content="https://wildstrokes.art/assets/c302bf84-6868-403c-8c0a-5e410fad1dae.png" />
+  <meta name="twitter:card" content="summary_large_image" />
+  <meta name="twitter:title" content="YCH Slots | WildStrokes" />
+  <meta name="twitter:description" content="Browse YCH slot offerings from WildStrokes." />
+  <meta name="twitter:image" content="https://wildstrokes.art/assets/c302bf84-6868-403c-8c0a-5e410fad1dae.png" />
   <link rel="stylesheet" href="../style.css" />
   <style>#content { display: none; }</style>
   <script src="../js/age-gate.js" defer></script>
+  <script src="/js/nav.js" defer></script>
   <script defer>
     document.addEventListener('DOMContentLoaded', () => initAgeGate());
   </script>
 </head>
 <body>
-  <nav class="site-nav">
-    <a href="/">Home</a>
-    <a href="/portfolio">Portfolio</a>
-    <a href="/ych">YCH</a>
-    <a href="https://ko-fi.com/wildstrokes" target="_blank">Kofi</a>
-    <a href="https://bsky.app/profile/wildstrokes.art" target="_blank">Bluesky</a>
-  </nav>
+  <div id="nav-placeholder"></div>
 
   <div id="content">
 


### PR DESCRIPTION
## Summary
- add SEO, Open Graph and Twitter metadata to main pages
- replace confirm dialog with styled modal age gate
- load shared navigation from external template and gate membership page

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68953bd8c968832fb27e473799df78d2