### PR TITLE
feat: add lightbox for YCH images

### DIFF
--- a/js/lightbox.js
+++ b/js/lightbox.js
@@ -1,0 +1,25 @@
+// Simple image lightbox for YCH cards
+// Creates a hidden overlay and exposes a global function to show it
+
+document.addEventListener('DOMContentLoaded', () => {
+  const overlay = document.createElement('div');
+  overlay.className = 'lightbox';
+  overlay.id = 'lightbox';
+
+  const img = document.createElement('img');
+  overlay.appendChild(img);
+
+  overlay.addEventListener('click', () => {
+    overlay.style.display = 'none';
+    img.src = '';
+  });
+
+  document.body.appendChild(overlay);
+
+  // Expose helper for other scripts
+  window.openLightbox = (src, alt = '') => {
+    img.src = src;
+    img.alt = alt;
+    overlay.style.display = 'flex';
+  };
+});

--- a/js/render-ych.js
+++ b/js/render-ych.js
@@ -28,6 +28,8 @@ document.addEventListener('DOMContentLoaded', async () => {
       const img = document.createElement('img');
       img.src = item.image;
       img.alt = `${item.title} YCH`;
+      img.loading = 'lazy';
+      img.addEventListener('click', () => openLightbox(img.src, img.alt));
       fig.appendChild(img);
 
       const cap = document.createElement('figcaption');

--- a/style.css
+++ b/style.css
@@ -88,6 +88,7 @@ body {
     height: auto;
     border-radius: 10px;
     margin-bottom: 10px;
+    cursor: pointer;
 }
 
 /* Badge styling */
@@ -237,4 +238,21 @@ button.button:hover {
 .age-gate-dialog button {
     margin: 0 10px;
     padding: 8px 16px;
+}
+
+/* Image lightbox */
+.lightbox {
+    position: fixed;
+    inset: 0;
+    background: rgba(0, 0, 0, 0.9);
+    display: none;
+    justify-content: center;
+    align-items: center;
+    z-index: 2000;
+}
+
+.lightbox img {
+    max-width: 90%;
+    max-height: 90%;
+    border-radius: 8px;
 }

--- a/ych/index.html
+++ b/ych/index.html
@@ -58,6 +58,7 @@
   </div>
 
   <button id="clearButton" onclick="clearAgeVerification()">Clear Age Verification</button>
+  <script src="../js/lightbox.js"></script>
   <script src="../js/render-ych.js"></script>
   <script src="../currency.js"></script>
 


### PR DESCRIPTION
## Summary
- add simple lightbox overlay for viewing YCH images at full size
- lazy load and attach lightbox open handler for each YCH image
- expose lightbox script and styles

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_6895496bd9f0832fa765f6850f6e91a4