### PR TITLE
Add campaign redirect pages for zine tracking

### DIFF
--- a/z-b/index.html
+++ b/z-b/index.html
@@ -1,0 +1,6 @@
+<!doctype html>
+<meta http-equiv="refresh" content="0; url=/zine/?utm_source=bsky&utm_medium=social">
+<meta name="robots" content="noindex">
+<link rel="canonical" href="/zine/?utm_source=bsky&utm_medium=social">
+<title>Redirecting…</title>
+<p><a href="/zine/?utm_source=bsky&utm_medium=social">Redirecting…</a></p>

--- a/z-e/index.html
+++ b/z-e/index.html
@@ -1,0 +1,6 @@
+<!doctype html>
+<meta http-equiv="refresh" content="0; url=/zine/?utm_source=e621&utm_medium=referral">
+<meta name="robots" content="noindex">
+<link rel="canonical" href="/zine/?utm_source=e621&utm_medium=referral">
+<title>Redirecting…</title>
+<p><a href="/zine/?utm_source=e621&utm_medium=referral">Redirecting…</a></p>

--- a/z-ea/index.html
+++ b/z-ea/index.html
@@ -1,0 +1,6 @@
+<!doctype html>
+<meta http-equiv="refresh" content="0; url=/zine/?utm_source=e621&utm_medium=display">
+<meta name="robots" content="noindex">
+<link rel="canonical" href="/zine/?utm_source=e621&utm_medium=display">
+<title>Redirecting…</title>
+<p><a href="/zine/?utm_source=e621&utm_medium=display">Redirecting…</a></p>

--- a/z-fa/index.html
+++ b/z-fa/index.html
@@ -1,0 +1,6 @@
+<!doctype html>
+<meta http-equiv="refresh" content="0; url=/zine/?utm_source=fa&utm_medium=referral">
+<meta name="robots" content="noindex">
+<link rel="canonical" href="/zine/?utm_source=fa&utm_medium=referral">
+<title>Redirecting…</title>
+<p><a href="/zine/?utm_source=fa&utm_medium=referral">Redirecting…</a></p>


### PR DESCRIPTION
## Summary
- add tiny HTML redirect pages for short campaign links (/z-b, /z-ea, /z-e, /z-fa)
- ensure noindex meta and canonical linking for accurate UTM tracking on /zine

## Testing
- `npm test` *(fails: Could not read package.json)*


------
https://chatgpt.com/codex/tasks/task_e_68c5adb2781c832f8f182a11a5423de8