### PR TITLE
Improve Piss Plaza Zine hero and CTAs

### DIFF
--- a/style.css
+++ b/style.css
@@ -256,3 +256,23 @@ button.button:hover {
     max-height: 90%;
     border-radius: 8px;
 }
+
+/* Hero */
+.hero { max-width: 720px; margin: 0 auto 24px; padding: 0 16px; }
+.hero h1 { margin: 0 0 8px; }
+.subhead { margin: 0 0 12px; font-size: 1.1rem; line-height: 1.5; }
+.hero-bullets { display: flex; flex-wrap: wrap; gap: 12px 20px; padding: 0; margin: 0 0 8px; list-style: none; }
+.hero-bullets li { white-space: nowrap; }
+
+/* CTAs */
+.cta-row { display: grid; grid-template-columns: 1fr 1fr; gap: 12px; max-width: 720px; margin: 12px auto 6px; padding: 0 16px; }
+.btn { display: inline-block; text-align: center; padding: 12px 16px; border-radius: 6px; text-decoration: none; border: 2px solid currentColor; min-height: 44px; }
+.btn-primary { color: #fff; background: #000; }
+.btn-secondary { background: transparent; }
+.cta-note { max-width: 720px; margin: 6px auto 16px; padding: 0 16px; font-size: .95rem; opacity: .85; }
+
+@media (max-width: 640px) {
+    .subhead { font-size: 1rem; }
+    .hero-bullets { gap: 8px 14px; }
+    .cta-row { grid-template-columns: 1fr; }
+}

--- a/zine/index.html
+++ b/zine/index.html
@@ -34,20 +34,27 @@
 <body>
   <div id="nav-placeholder"></div>
   <div id="content">
-    <header class="site-header">
-      <h1>Piss Plaza Zine</h1>
-    </header>
+      <section class="hero">
+        <h1>Piss Plaza Zine</h1>
+        <p class="subhead">A 24-page NSFW furry watersports zine set in an abandoned mall.</p>
+        <ul class="hero-bullets">
+          <li>10 short stories</li>
+          <li>10 illustrations</li>
+          <li>PDF + optional print</li>
+        </ul>
+      </section>
 
-    <img src="/zine/PissPlazaCover.jpg" alt="Piss Plaza zine cover by WildStrokes." class="feature-image" loading="lazy" />
+      <div class="cta-row">
+        <a id="physical-link" class="btn btn-primary" href="https://mixam.com/print-on-demand/68c096b877b4144e89f697e6">Buy Physical — $15</a>
+        <a class="btn btn-secondary" href="https://ko-fi.com/wildstrokes/tiers">Get Digital (Splash Zone) — $5/mo</a>
+      </div>
+      <p class="cta-note">Digital file available after joining via members-only Telegram channel. Launch price ends Sun, Sept 21 (America/Chicago).</p>
 
-    <p><strong>18+ NSFW. Contains kink content (watersports).</strong></p>
+      <p><strong>18+ NSFW. Contains kink content (watersports).</strong></p>
 
-    <p>This zine is a weird little experiment: ten short stories, each paired with an illustration, all circling one simple but specific idea: anthros pissing in an abandoned mall. It’s unapologetically niche, unashamedly NSFW, and made for the piss/furry community. It’s not trying to be big or broad; this is for the people who get it, who like seeing kink explored in strange, offbeat ways. If that’s you, you’re home. If not, no worries. This project isn’t for everyone, and that’s the point.</p>
+      <img src="/zine/PissPlazaCover.jpg" alt="Piss Plaza zine cover by WildStrokes." class="feature-image" loading="lazy" />
 
-    <div>
-      <a id="physical-link" class="button" href="https://mixam.com/print-on-demand/68c096b877b4144e89f697e6">Buy Physical – $15 (launch price)</a>
-      <p>Launch price ends Sunday, September 21, 2025. Regular price $20.<br />Printed via Mixam. Shipping shown at checkout.</p>
-    </div>
+      <p>This zine is a weird little experiment: ten short stories, each paired with an illustration, all circling one simple but specific idea: anthros pissing in an abandoned mall. It’s unapologetically niche, unashamedly NSFW, and made for the piss/furry community. It’s not trying to be big or broad; this is for the people who get it, who like seeing kink explored in strange, offbeat ways. If that’s you, you’re home. If not, no worries. This project isn’t for everyone, and that’s the point.</p>
 
     <section>
       <h2>Get the digital version</h2>


### PR DESCRIPTION
## Summary
- Replace introductory content with concise hero section and bullet list for Piss Plaza Zine.
- Add standardized call-to-action buttons for physical and digital versions with pricing and note.
- Include supporting styles for hero layout and CTA buttons.

## Testing
- `npm test` *(fails: could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68c5c912d96c832fa75f6db0d8638338