### PR TITLE
Add sale countdown banner for zine launch

### DIFF
--- a/style.css
+++ b/style.css
@@ -14,6 +14,14 @@ body {
     margin: 0 auto;
 }
 
+/* Sale banner */
+.sale-banner {
+    background-color: #fff3cd;
+    color: #333;
+    padding: 10px;
+    font-weight: bold;
+}
+
 /* Header */
 .site-header {
     margin-bottom: 40px;

--- a/zine/index.html
+++ b/zine/index.html
@@ -34,6 +34,7 @@
 <body>
   <div id="nav-placeholder"></div>
   <div id="content">
+    <div id="sale-banner" class="sale-banner"></div>
       <section class="hero">
         <h1>Piss Plaza Zine</h1>
         <p class="subhead">A 24-page NSFW furry watersports zine set in an abandoned mall.</p>
@@ -45,10 +46,10 @@
       </section>
 
       <div class="cta-row">
-        <a id="physical-link" class="btn btn-primary" href="https://mixam.com/print-on-demand/68c096b877b4144e89f697e6">Buy Physical — $15</a>
+        <a id="physical-link" class="btn btn-primary" href="https://mixam.com/print-on-demand/68c096b877b4144e89f697e6">Buy Physical — <s>$20</s> $15</a>
         <a class="btn btn-secondary" href="https://ko-fi.com/wildstrokes/tiers">Get Digital (Splash Zone) — $5/mo</a>
       </div>
-      <p class="cta-note">Digital file available after joining via members-only Telegram channel. Launch price ends Sun, Sept 21 (America/Chicago).</p>
+      <p class="cta-note">Digital file available after joining via members-only Telegram channel.</p>
 
       <p><strong>18+ NSFW. Contains kink content (watersports).</strong></p>
 
@@ -84,6 +85,24 @@
         physical.href += query;
       }
     }
+  </script>
+  <script>
+    const saleEnd = new Date('2024-09-21T23:59:59-05:00');
+    const saleBanner = document.getElementById('sale-banner');
+    function updateSaleBanner() {
+      const now = new Date();
+      const diff = saleEnd - now;
+      if (diff <= 0) {
+        saleBanner.textContent = 'Sale has ended';
+        clearInterval(intervalId);
+        return;
+      }
+      const days = Math.floor(diff / (1000 * 60 * 60 * 24));
+      const hours = Math.floor((diff / (1000 * 60 * 60)) % 24);
+      saleBanner.textContent = `Sale ends in ${days} days and ${hours} hours`;
+    }
+    updateSaleBanner();
+    const intervalId = setInterval(updateSaleBanner, 60 * 60 * 1000);
   </script>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- Add top-of-page sale banner with live countdown to launch price end
- Update physical zine button to show strike-through original price and sale price
- Remove static sale end text and style new sale banner

## Testing
- `npm test` *(fails: ENOENT: no such file or directory, open 'package.json')*


------
https://chatgpt.com/codex/tasks/task_e_68c5ea7644c8832f80e55f55a7e73aa6