### PR TITLE
Update sale banner styling and timing

### DIFF
--- a/style.css
+++ b/style.css
@@ -16,10 +16,12 @@ body {
 
 /* Sale banner */
 .sale-banner {
-    background-color: #fff3cd;
-    color: #333;
+    background-color: #4b0082;
+    color: #fff;
     padding: 10px;
     font-weight: bold;
+    text-align: center;
+    width: 100%;
 }
 
 /* Header */

--- a/zine/index.html
+++ b/zine/index.html
@@ -33,8 +33,8 @@
 </head>
 <body>
   <div id="nav-placeholder"></div>
+  <div id="sale-banner" class="sale-banner"></div>
   <div id="content">
-    <div id="sale-banner" class="sale-banner"></div>
       <section class="hero">
         <h1>Piss Plaza Zine</h1>
         <p class="subhead">A 24-page NSFW furry watersports zine set in an abandoned mall.</p>
@@ -87,8 +87,15 @@
     }
   </script>
   <script>
-    const saleEnd = new Date('2024-09-21T23:59:59-05:00');
     const saleBanner = document.getElementById('sale-banner');
+    const saleEnd = (() => {
+      const now = new Date();
+      const daysUntilNextSunday = ((7 - now.getDay()) % 7) || 7;
+      const end = new Date(now);
+      end.setDate(now.getDate() + daysUntilNextSunday);
+      end.setHours(23, 59, 59, 999);
+      return end;
+    })();
     function updateSaleBanner() {
       const now = new Date();
       const diff = saleEnd - now;


### PR DESCRIPTION
## Summary
- Use full-width dark purple banner for sale notices
- Automatically set sale end to next Sunday with countdown

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68c5ec0f3b98832fbcdc7b9af4ceb524