### PR TITLE
Improve zine sale banner

### DIFF
--- a/style.css
+++ b/style.css
@@ -21,7 +21,13 @@ body {
     padding: 10px;
     font-weight: bold;
     text-align: center;
-    width: 100%;
+    width: 100vw;
+    position: relative;
+    left: 50%;
+    right: 50%;
+    margin-left: -50vw;
+    margin-right: -50vw;
+    margin-bottom: 20px;
 }
 
 /* Header */

--- a/zine/index.html
+++ b/zine/index.html
@@ -92,10 +92,15 @@
       const now = new Date();
       const daysUntilNextSunday = ((7 - now.getDay()) % 7) || 7;
       const end = new Date(now);
-      end.setDate(now.getDate() + daysUntilNextSunday);
+      end.setDate(now.getDate() + daysUntilNextSunday + 7); // one week from next Sunday
       end.setHours(23, 59, 59, 999);
       return end;
     })();
+
+    function pluralize(value, unit) {
+      return `${value} ${unit}${value === 1 ? '' : 's'}`;
+    }
+
     function updateSaleBanner() {
       const now = new Date();
       const diff = saleEnd - now;
@@ -106,8 +111,19 @@
       }
       const days = Math.floor(diff / (1000 * 60 * 60 * 24));
       const hours = Math.floor((diff / (1000 * 60 * 60)) % 24);
-      saleBanner.textContent = `Sale ends in ${days} days and ${hours} hours`;
+
+      let message = 'Sale ends in ';
+      if (days > 0) {
+        message += pluralize(days, 'day');
+        if (hours > 0) {
+          message += ` and ${pluralize(hours, 'hour')}`;
+        }
+      } else {
+        message += pluralize(hours, 'hour');
+      }
+      saleBanner.textContent = message;
     }
+
     updateSaleBanner();
     const intervalId = setInterval(updateSaleBanner, 60 * 60 * 1000);
   </script>


### PR DESCRIPTION
## Summary
- Expand sale banner to full-width purple bar
- Dynamically calculate sale end one week after next Sunday
- Use singular or plural time units for banner countdown

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68c5ee5ea834832fb713e363404dc120