### PR TITLE
Add Zine to site navigation

### DIFF
--- a/nav.html
+++ b/nav.html
@@ -2,6 +2,7 @@
   <a href="/">Home</a>
   <a href="/portfolio">Portfolio</a>
   <a href="/ych">YCH</a>
+  <a href="/zine">Zine</a>
   <a href="https://ko-fi.com/wildstrokes" target="_blank">Kofi</a>
   <a href="https://bsky.app/profile/wildstrokes.art" target="_blank">Bluesky</a>
 </nav>

--- a/ych/editor.html
+++ b/ych/editor.html
@@ -25,6 +25,7 @@
     <a href="/">Home</a>
     <a href="/portfolio">Portfolio</a>
     <a href="/ych">YCH</a>
+    <a href="/zine">Zine</a>
     <a href="https://ko-fi.com/wildstrokes" target="_blank">Kofi</a>
     <a href="https://bsky.app/profile/wildstrokes.art" target="_blank">Bluesky</a>
   </nav>


### PR DESCRIPTION
## Summary
- add Zine link to main navigation so it's accessible across the site
- include Zine link in YCH editor navigation for consistency

## Testing
- `npm test` *(fails: missing package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68c5ffc6d368832f9d12b174c7b8ee34