### PR TITLE
Replace zine cover image with latest version

### DIFF
--- a/zine/index.html
+++ b/zine/index.html
@@ -9,11 +9,11 @@
   <meta property="og:description" content="Ten short stories with illustrations about anthros pissing in an abandoned mall." />
   <meta property="og:type" content="website" />
   <meta property="og:url" content="https://wildstrokes.art/zine/" />
-  <meta property="og:image" content="https://wildstrokes.art/zine/PissPlazaCover.jpg" />
+  <meta property="og:image" content="https://wildstrokes.art/zine/8637541b-076e-4419-b340-e3e43ca345bd.jpeg" />
   <meta name="twitter:card" content="summary_large_image" />
   <meta name="twitter:title" content="Piss Plaza Zine | WildStrokes" />
   <meta name="twitter:description" content="Ten short stories with illustrations about anthros pissing in an abandoned mall." />
-  <meta name="twitter:image" content="https://wildstrokes.art/zine/PissPlazaCover.jpg" />
+  <meta name="twitter:image" content="https://wildstrokes.art/zine/8637541b-076e-4419-b340-e3e43ca345bd.jpeg" />
   <link rel="stylesheet" href="../style.css" />
   <!-- Google tag (gtag.js) -->
   <script async src="https://www.googletagmanager.com/gtag/js?id=G-CNSS235NES"></script>
@@ -51,7 +51,7 @@
 
       <p><strong>18+ NSFW. Contains kink content (watersports).</strong></p>
 
-      <img src="/zine/PissPlazaCover.jpg" alt="Piss Plaza zine cover by WildStrokes." class="feature-image" loading="lazy" />
+      <img src="/zine/8637541b-076e-4419-b340-e3e43ca345bd.jpeg" alt="Piss Plaza zine cover by WildStrokes." class="feature-image" loading="lazy" />
 
       <p>This zine is a weird little experiment: ten short stories, each paired with an illustration, all circling one simple but specific idea: anthros pissing in an abandoned mall. It’s unapologetically niche, unashamedly NSFW, and made for the piss/furry community. It’s not trying to be big or broad; this is for the people who get it, who like seeing kink explored in strange, offbeat ways. If that’s you, you’re home. If not, no worries. This project isn’t for everyone, and that’s the point.</p>
 


### PR DESCRIPTION
## Summary
- update the Piss Plaza zine page metadata and feature image to use the new cover photo

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d4b3bfde68832f9b3ab62a77dbd0b3