### PR TITLE
Move zine cover image beneath title

### DIFF
--- a/zine/index.html
+++ b/zine/index.html
@@ -36,6 +36,7 @@
   <div id="content">
       <section class="hero">
         <h1>Piss Plaza Zine</h1>
+        <img src="/zine/8637541b-076e-4419-b340-e3e43ca345bd.jpeg" alt="Piss Plaza zine cover by WildStrokes." class="feature-image" loading="lazy" />
         <p class="subhead">A 24-page NSFW furry watersports zine set in an abandoned mall.</p>
           <ul class="hero-bullets">
           <li>10 short stories</li>
@@ -50,9 +51,6 @@
       <p class="cta-note">Digital file available after joining via members-only Telegram channel.</p>
 
       <p><strong>18+ NSFW. Contains kink content (watersports).</strong></p>
-
-      <img src="/zine/8637541b-076e-4419-b340-e3e43ca345bd.jpeg" alt="Piss Plaza zine cover by WildStrokes." class="feature-image" loading="lazy" />
-
       <p>This zine is a weird little experiment: ten short stories, each paired with an illustration, all circling one simple but specific idea: anthros pissing in an abandoned mall. It’s unapologetically niche, unashamedly NSFW, and made for the piss/furry community. It’s not trying to be big or broad; this is for the people who get it, who like seeing kink explored in strange, offbeat ways. If that’s you, you’re home. If not, no worries. This project isn’t for everyone, and that’s the point.</p>
 
     <section>


### PR DESCRIPTION
## Summary
- move the zine cover image directly under the main heading so it appears before the subheading

## Testing
- no tests were run (not applicable)

------
https://chatgpt.com/codex/tasks/task_e_68d4b5078b50832f943eee3e29ffd43e