### PR TITLE
Add fast /kofi redirect to Ko‑fi tiers

### DIFF
--- a/kofi/index.html
+++ b/kofi/index.html
@@ -1,0 +1,20 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Redirecting to Ko-fi…</title>
+    <link rel="canonical" href="https://ko-fi.com/wildstrokes/tiers" />
+    <meta http-equiv="refresh" content="0; url=https://ko-fi.com/wildstrokes/tiers" />
+    <script>
+      window.location.replace("https://ko-fi.com/wildstrokes/tiers");
+    </script>
+  </head>
+  <body>
+    <p>
+      Redirecting to
+      <a href="https://ko-fi.com/wildstrokes/tiers">https://ko-fi.com/wildstrokes/tiers</a>
+      …
+    </p>
+  </body>
+</html>


### PR DESCRIPTION
### Motivation
- Provide a simple, fast redirect so visits to `/kofi` go directly to the Ko‑fi tiers page at `https://ko-fi.com/wildstrokes/tiers` for user convenience and sharing.

### Description
- Added `kofi/index.html` which performs an immediate redirect to `https://ko-fi.com/wildstrokes/tiers`.
- The page uses a `meta` refresh, `window.location.replace(...)` for quick client-side navigation, and a `rel="canonical"` link for correctness.
- A plain anchor fallback is included in the body for users with scripting or refresh disabled.

### Testing
- Ran a local static server with `python3 -m http.server` and verified the redirect page content with `curl`, which showed the `meta` refresh, `window.location.replace`, and the fallback link, and the check succeeded.
- Loaded `/kofi/` with Playwright which navigated to `https://ko-fi.com/wildstrokes/tiers` and produced a screenshot artifact, and the test succeeded.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69aca7874390832fb7e329c983ec7355)